### PR TITLE
chore: update reference to `policy` repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,13 +9,13 @@ git_services:
       - conforma/.github
       - conforma/go-gather
       - conforma/hacks
+      - conforma/policy
       - conforma/review-rot
       - conforma/tekton-catalog
       - conforma/user-guide
       - enterprise-contract/action-validate-image
       - enterprise-contract/config
       - enterprise-contract/ec-cli
-      - enterprise-contract/ec-policies
       - enterprise-contract/enterprise-contract-controller
       - enterprise-contract/.github
       - enterprise-contract/github-workflows


### PR DESCRIPTION
This commit updates the reference to the `policy` repo from `enterprise-contract/ec-policies` to `conforma/policy`.

Ref: EC-1113