### PR TITLE
Group automated PRs into their own section

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 arguments:
   format: json
   reverse: True
+  categorize_automated: True
 git_services:
   - host: github.com
     repos:


### PR DESCRIPTION
This commit adds a new parameter in the config file that enables the grouping of the PRs coming from bots (renovate, dependabot) into their own section.

This should leave us with a tidier section with only human PRs