### PR TITLE
chore: update references to config repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ git_services:
       - conforma/review-rot
       - conforma/tekton-catalog
       - conforma/user-guide
-      - enterprise-contract/config
+      - conforma/config
       - enterprise-contract/enterprise-contract-controller
       - enterprise-contract/.github
       - enterprise-contract/github-workflows


### PR DESCRIPTION
This commit updates references from `enterprise-contract/config` to `conforma/config`.