### PR TITLE
Conforma controller replaced by knative service

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ git_services:
       - conforma/cli
       - conforma/community
       - conforma/conforma.github.io
-      - conforma/controller
+      - conforma/knative-service
       - conforma/demos
       - conforma/github-workflows
       - conforma/go-containerregistry


### PR DESCRIPTION
The conforma controller was abandoned and replaced by a knative service, so replacing the repo name.